### PR TITLE
feat: Exchange rates active on market page

### DIFF
--- a/frontend/src/app/market/page.tsx
+++ b/frontend/src/app/market/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import useFetchData from "@/hooks/useFetchData";
-import { getMarketGrainPrices } from "@/services";
+import { getExchangeRates, getMarketGrainPrices } from "@/services";
 import Head from "next/head";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -10,22 +10,29 @@ import CurrencyExchange from "../../components/market/CurrencyExchange";
 import AgriculturalInputs from "../../components/market/AgriculturalInputs";
 import Header from "../common/Header";
 
-interface CropPricesProps {
-  marketData: string; // Replace 'any' with the actual type of marketData
-}
 const Market = () => {
   const { fetchData } = useFetchData();
   const [marketData, setMarketData] = useState({});
+  const [exchangeRates, setExchangeRates] = useState({});
+
 
   useEffect(() => {
     const getMarketData = async () => {
       const { ok, data } = await fetchData(getMarketGrainPrices, {});
       ok
         ? setMarketData(data)
-        : toast.error("no se pudo traer la infromacion del mercado");
+        : toast.error("no se pudo traer la informacion del mercado");
+    };
+
+    const getMoneyData = async () => {
+      const { ok, data } = await fetchData(getExchangeRates, {});
+      ok
+        ? setExchangeRates(data)
+        : toast.error("no se pudo traer la informacion de tasas de cambio");
     };
 
     getMarketData();
+    getMoneyData();
   }, []);
 
   return (
@@ -43,7 +50,7 @@ const Market = () => {
           </h1>
           <div className="space-y-8 ">
             <CropPrices marketData={marketData} />
-            <CurrencyExchange />
+            <CurrencyExchange exchangeRates={exchangeRates} />
             <AgriculturalInputs />
           </div>
         </main>

--- a/frontend/src/components/market/CurrencyExchange.tsx
+++ b/frontend/src/components/market/CurrencyExchange.tsx
@@ -1,8 +1,18 @@
 import React from 'react';
+import { getExchangeRates } from '../../services/index';
 
-const currencies = ['Dólar BNA', 'Dólar Blue', 'Euro', 'Real', 'Yuan Chino'];
+interface ExchangeRate {
+  dollar: string;
+  buy: string;
+  sell: string;
+}
 
-const CurrencyExchange: React.FC = () => {
+interface CurrencyExchangeProps {
+  exchangeRates: { [currency: string]: ExchangeRate };
+}
+
+const CurrencyExchange: React.FC<CurrencyExchangeProps> = ({exchangeRates}) => {
+  console.log(exchangeRates)
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
       <h2 className="text-2xl font-semibold mb-4">Cotización dólar</h2>
@@ -10,22 +20,22 @@ const CurrencyExchange: React.FC = () => {
         <table className="w-full">
           <thead>
             <tr>
-              {currencies.map((currency) => (
-                <th key={currency} className="px-4 py-2">{currency}</th>
+            {Object.entries(exchangeRates).map(([currency, {dollar}]) => (
+                <th key={dollar} className="px-4 py-2">{dollar}</th>
               ))}
             </tr>
           </thead>
           <tbody>
             <tr>
-              {currencies.map((currency) => (
+              {Object.entries(exchangeRates).map(([currency, {buy, sell}]) => (
                 <td key={currency} className="border px-4 py-2">
                   <div className="flex justify-between">
                     <span>Compra</span>
                     <span>Venta</span>
                   </div>
                   <div className="flex justify-between font-semibold">
-                    <span>$265</span>
-                    <span>$265</span>
+                    <span>${buy}</span>
+                    <span>${sell}</span>
                   </div>
                 </td>
               ))}

--- a/frontend/src/services/index.ts
+++ b/frontend/src/services/index.ts
@@ -30,3 +30,4 @@ export const createCampo = async <T>({ body }: FuntionProps<T>) =>
 // Market services
 
 export const getMarketGrainPrices = async () => await api.get("/market");
+export const getExchangeRates = async () => await api.get("/dollar");


### PR DESCRIPTION
@everyone @FrontEnd. Se traen los datos del endpoint backend /dollar para mostrarlos en la sección tasas de cambio de la página market.

![image](https://github.com/user-attachments/assets/025326e1-6d19-4fd8-a764-67ea7e309e12)
