### PR TITLE
style: show button at bottom in smal devices

### DIFF
--- a/frontend/.env example
+++ b/frontend/.env example
@@ -1,0 +1,1 @@
+<!-- NEXT_PUBLIC_URL_BASE = https://deploy-name/api/v0 -->

--- a/frontend/src/app/myFields/createField/page.tsx
+++ b/frontend/src/app/myFields/createField/page.tsx
@@ -176,7 +176,7 @@ const CreateField: React.FC = () => {
           </div>
         </div>
 
-        <div className="py-2">
+        <div className="pt-20 md:pt-0">
           <SubmitButton value="Agregar" />
         </div>
       </form>


### PR DESCRIPTION
Hola @everyone. Se hizo un ajuste al botón crear campo, para que se muestre por debajo de las cajas de texto para móviles. Favor atender.

![image](https://github.com/user-attachments/assets/9298e010-178a-43ad-83d5-d4ca436f1f38)

